### PR TITLE
fix: consider lang when creating code hash for firestore storer

### DIFF
--- a/src/storage/firestore.js
+++ b/src/storage/firestore.js
@@ -2,9 +2,9 @@ import { createHash } from "crypto";
 import { NotFoundError, DecodeIdError } from "../errors/http.js";
 import admin from "firebase-admin";
 
-const createCodeHash = code =>
+const createCodeHash = ({ lang, code }) =>
   createHash("sha256")
-    .update(JSON.stringify(code))
+    .update(JSON.stringify({ lang, code }))
     .digest("hex");
 
 export const encodeId = ({ taskIds }) => {
@@ -50,7 +50,7 @@ const appendIds = (id, ...otherIds) => {
 
 const buildTaskCreate = ({ db }) => async ({ task, auth }) => {
   const { lang, code } = task;
-  const codeHash = createCodeHash(code);
+  const codeHash = createCodeHash({ lang, code });
 
   const codeHashRef = db.doc(`code-hashes/${codeHash}`);
   const codeHashDoc = await codeHashRef.get();

--- a/src/storage/firestore.spec.js
+++ b/src/storage/firestore.spec.js
@@ -40,6 +40,20 @@ describe("storage/firestore", () => {
     await expect(taskDao.get({ id: multiId })).resolves.toStrictEqual([TASK1, TASK2]);
   });
 
+  it("should get different ids for same code and different langs", async () => {
+    const id1 = await taskDao.create({ task: { lang: "0", code: TASK1.code } });
+    const id2 = await taskDao.create({ task: { lang: "1", code: TASK1.code } });
+
+    await expect(id1).not.toBe(id2);
+  });
+
+  it("should get same id for same lang and code with different extra properties", async () => {
+    const id1 = await taskDao.create({ task: { ...TASK1, foo: "bar" } });
+    const id2 = await taskDao.create({ task: { ...TASK1, foo: "baz" } });
+
+    await expect(id1).toBe(id2);
+  });
+
   it("should get appended task ids", async () => {
     const id1 = await taskDao.create({ task: TASK1 });
     const id2 = await taskDao.create({ task: TASK2 });

--- a/src/storage/memory.spec.js
+++ b/src/storage/memory.spec.js
@@ -33,6 +33,20 @@ describe("storage/memory", () => {
     await expect(taskDao.get({ id })).resolves.toStrictEqual([TASK1, TASK2]);
   });
 
+  it("should get different ids for same code and different langs", async () => {
+    const id1 = await taskDao.create({ task: { lang: "0", code: TASK1.code } });
+    const id2 = await taskDao.create({ task: { lang: "1", code: TASK1.code } });
+
+    await expect(id1).not.toBe(id2);
+  });
+
+  it("should get same id for same lang and code with different extra properties", async () => {
+    const id1 = await taskDao.create({ task: { ...TASK1, foo: "bar" } });
+    const id2 = await taskDao.create({ task: { ...TASK1, foo: "baz" } });
+
+    await expect(id1).toBe(id2);
+  });
+
   it("should throw NotFoundError retrieved without auth", async () => {
     const auth = { uid: "1" };
     const id = await taskDao.create({ task: TASK1, auth });


### PR DESCRIPTION
@jeffdyer LMK if this is what you were thinking for incorporating lang into the firestore code hashes